### PR TITLE
Support for v6.2.x of Elastic Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 * Support Elasticsearch v6.2.x. See https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-6.0.html for more info.
 
+Note: Contains breaking changes to the mapping API:
+
+```ruby
+mapping name: 'default', field: :name, type: :string, analyser: :not_analyzed
+```
+
+must be changed to use the new format:
+
+```ruby
+mapping name: 'default', field: :name, type: :keyword, index: true
+```
+
 ## v0.2.4
 
 * Bugfix to catch and surpress index already exists error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## v1.0.0
+
+* Support Elasticsearch v6.2.x. See https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-6.0.html for more info.
+
+## v0.2.4
+
+* Bugfix to catch and surpress index already exists error.

--- a/README.md
+++ b/README.md
@@ -29,41 +29,43 @@ The namespace is used to set the prefix applied to all table and index names.
 > Optional.
 
     elasticsearchFramework.namespace = 'uat'
-    
+
 > With a namespace of 'uat' and a table name of 'people', the resulting table name would be 'uat.people'
-    
+
 ### #namespace_delimiter
 This is the delimiter used to join the namespace prefix to table/index names.
 
 > DEFAULT = '.'
 
     elasticsearchFramework.namespace_delimiter = '-'
-    
+
 ### #host
 This is used to set the host that should be used for all connection actions.
 
     ElasticSearchFramework.host = 'http://elasticsearch'
-    
+
 ### #port
 This is used to set the port that should be used for all connection actions.
 
     ElasticSearchFramework.port = 9200
-    
+
 > DEFAULT = 9200
 
 # Index
 To define an index within elasticsearch, create an index definition class that extends from the `ElasticSearchFramework::Index` module.
 
-    class ExampleIndex
-      extend ElasticSearchFramework::Index
-    
-      index name: 'example_index', shards: 1
-      
-      id :example_id
-      
-      mapping name: 'default', field: :name, type: :string, analyser: :not_analyzed    
-    end
-    
+```ruby
+class ExampleIndex
+  extend ElasticSearchFramework::Index
+
+  index name: 'example_index', shards: 1
+
+  id :example_id
+
+  mapping name: 'default', field: :name, type: :keyword, index: true
+end
+```
+
 **attributes**
 
  - **index** [Hash] [Required] This is used to specify the name of the index, and the number of shards the index should use.
@@ -74,24 +76,24 @@ To define an index within elasticsearch, create an index definition class that e
 This method is called to create the index definition within an elastic search instance.
 
     ExampleIndex.create
- 
- 
+
+
 ## #drop
 This method is called to drop the index from an elastic search instance.
 
     ExampleIndex.drop
-  
+
 ## #exists?
 This method is called to determine if an index exists in a elastic search instance.
 
     ExampleIndex.exists?
-    
+
 
 ## #put_item
 This method is called to store a document/entity within the index.
 
     ExampleIndex.put_item(item: document)
-    
+
 **Params**
 
  - **item** [Object] [Required] This is the document/entity you want to store in the index.
@@ -101,7 +103,7 @@ This method is called to store a document/entity within the index.
 This method is called to fetch a document from within the index.
 
     ExampleIndex.get_item(id: document_id)
-    
+
 **Params**
 
  - **id** [String/Integer] [Required] This is the unique identifier of the document/entity you want to fetch from the index.
@@ -111,7 +113,7 @@ This method is called to fetch a document from within the index.
 This method is called to delete a document from within the index.
 
     ExampleIndex.delete_item(id: document_id)
-    
+
 **Params**
 
  - **id** [String/Integer] [Required] This is the unique identifier of the document/entity you want to delete from the index.
@@ -125,17 +127,17 @@ This method is called to query the index for a collection of items.
 The query is then built up using method chaining e.g:
 
     query = ExampleIndex.query.gender.eq('male').and.age.gt(18)
-    
+
 The above query chain translates into:
 
     FROM ExampleIndex WHERE gender == 'male' AND age > 18
-     
+
 To execute the query you can then call `#execute` on the query:
 
     query.execute
-    
+
 > Due to method chaining, the #execute method can also be chained to the end of a query directly.
-    
+
 ### #execute
 This method is called to execute a query.
 
@@ -173,7 +175,7 @@ This method is called to check if a field exists within a query.
 ### #and
 This method is called to combine conditions together in a traditional `&&` method within a query.
 
-### #or 
+### #or
 This method is called to combine conditions together in a traditional `||` method within a query.
 
 ## Development

--- a/lib/elastic_search_framework/index.rb
+++ b/lib/elastic_search_framework/index.rb
@@ -18,7 +18,7 @@ module ElasticSearchFramework
       end
     end
 
-    def mapping(name:, field:, type:, analyser:)
+    def mapping(name:, field:, type:, index:)
 
       unless instance_variable_defined?(:@elastic_search_index_mappings)
         instance_variable_set(:@elastic_search_index_mappings, {})
@@ -30,7 +30,7 @@ module ElasticSearchFramework
         mappings[name] = {}
       end
 
-      mappings[name][field] = { type: type, analyser: analyser}
+      mappings[name][field] = { type: type, index: index}
 
       instance_variable_set(:@elastic_search_index_mappings, mappings)
 
@@ -127,7 +127,7 @@ module ElasticSearchFramework
           mappings[name].keys.each do |field|
             payload[:mappings][name][:properties][field] = {
                 type: mappings[name][field][:type],
-                index: mappings[name][field][:analyser]
+                index: mappings[name][field][:index]
             }
           end
         end

--- a/lib/elastic_search_framework/index.rb
+++ b/lib/elastic_search_framework/index.rb
@@ -58,6 +58,7 @@ module ElasticSearchFramework
 
       request = Net::HTTP::Put.new(uri.request_uri)
       request.body = JSON.dump(payload)
+      request.content_type = 'application/json'
 
       response = repository.with_client do |client|
         client.request(request)

--- a/lib/elastic_search_framework/repository.rb
+++ b/lib/elastic_search_framework/repository.rb
@@ -7,6 +7,7 @@ module ElasticSearchFramework
 
       request = Net::HTTP::Put.new(uri.request_uri)
       request.body = JSON.dump(hash)
+      request.content_type = 'application/json'
 
       response = with_client do |client|
         client.request(request)

--- a/lib/elastic_search_framework/version.rb
+++ b/lib/elastic_search_framework/version.rb
@@ -1,3 +1,3 @@
 module ElasticSearchFramework
-  VERSION = '0.2.4'
+  VERSION = '1.0.0'
 end

--- a/spec/example_index.rb
+++ b/spec/example_index.rb
@@ -3,7 +3,7 @@ class ExampleIndex
 
   index name: 'example_index'
 
-  mapping name: 'default', field: :name, type: :string, analyser: :not_analyzed
+  mapping name: 'default', field: :name, type: :keyword, index: true
 
 end
 
@@ -14,7 +14,7 @@ class ExampleIndexWithId
 
   id :number
 
-  mapping name: 'default', field: :name, type: :string, analyser: :not_analyzed
+  mapping name: 'default', field: :name, type: :keyword, index: true
 
 end
 
@@ -23,7 +23,7 @@ class ExampleIndexWithShard
 
   index name: 'example_index', shards: 1
 
-  mapping name: 'default', field: :name, type: :string, analyser: :not_analyzed
+  mapping name: 'default', field: :name, type: :keyword, index: true
 
 end
 

--- a/spec/index_spec.rb
+++ b/spec/index_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe ElasticSearchFramework::Index do
       mappings = ExampleIndex.mappings
       expect(mappings).to be_a(Hash)
       expect(mappings.length).to eq 1
-      expect(mappings['default'][:name][:type]).to eq :string
-      expect(mappings['default'][:name][:analyser]).to eq :not_analyzed
+      expect(mappings['default'][:name][:type]).to eq :keyword
+      expect(mappings['default'][:name][:index]).to eq true
     end
   end
 


### PR DESCRIPTION
Enable support for v6.2.x of elastic search.


* Replace `string` type and `not_analyzed` analyzer. (https://www.elastic.co/blog/strings-are-dead-long-live-strings)
* Set content-type header for put requests (https://www.elastic.co/blog/strict-content-type-checking-for-elasticsearch-rest-requests)

TravisCI build currently running on v5.5.0 so will leave this to ensure backwards compatibility. Running locally against v6.2.3 this is passing also.