### PR TITLE
Resolve contains? query method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.1.0
+
+* Fix the eq and contains? queries.
+The contains? method. This was doing the same thing as the eq method. Added the wildcard symbols to match the queries we were running using kibana.
+The condition type. I've updated this to always do `value.to_s` as ES accepts a String value in the query for searches.
+
 ## v1.0.0
 
 * Support Elasticsearch v6.2.x. See https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-6.0.html for more info.

--- a/lib/elastic_search_framework/query.rb
+++ b/lib/elastic_search_framework/query.rb
@@ -23,7 +23,7 @@ module ElasticSearchFramework
     end
 
     def contains?(value)
-      condition(expression: ':', value: value)
+      condition(expression: ':', value: "*#{value}*")
       self
     end
 
@@ -91,11 +91,11 @@ module ElasticSearchFramework
           when :field
             @expression_string += ' ' + p[:value].to_s
           when :condition
-            @expression_string += p[:expression].to_s + format_value(p[:value])
+            @expression_string += p[:expression].to_s + p[:value].to_s
           when :exists
             @expression_string += ' _exists_:' + p[:field].to_s
           when :not_eq
-            @expression_string += ' NOT (' + p[:field].to_s + ':' + format_value(p[:value]) + ')'
+            @expression_string += ' NOT (' + p[:field].to_s + ':' + p[:value].to_s + ')'
           when :and
             @expression_string += ' AND'
           when :or
@@ -111,14 +111,5 @@ module ElasticSearchFramework
     def condition(expression:, value:)
       @parts << { type: :condition, expression: expression, value: value }
     end
-
-    def format_value(value)
-      result = value.to_s
-      if value.is_a?(String)
-        result = '"' + value + '"'
-      end
-      result
-    end
-
   end
 end

--- a/lib/elastic_search_framework/version.rb
+++ b/lib/elastic_search_framework/version.rb
@@ -1,3 +1,3 @@
 module ElasticSearchFramework
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe ElasticSearchFramework::Query do
 
   subject do
@@ -70,13 +72,21 @@ RSpec.describe ElasticSearchFramework::Query do
       results = ExampleIndex.query.number.gt_eq(15).execute
       expect(results.length).to eq 2
 
+      results = ExampleIndex.query.number.lt(15).execute
+      expect(results.length).to eq 2
+
+      results = ExampleIndex.query.number.lt_eq(15).execute
+      expect(results.length).to eq 3
+
       results = ExampleIndex.query.name.not_eq('john').execute
       expect(results.length).to eq 3
+
+      results = ExampleIndex.query.name.contains?('oh').execute
+      expect(results.length).to eq 1
     end
 
     after do
       ExampleIndex.delete
     end
   end
-
 end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ElasticSearchFramework::Query do
   describe '#build' do
     it 'should build the expected query string' do
       subject.name.eq('fred').and.age.gt(18).and.gender.not_eq('male')
-      expect(subject.build).to eq 'name:"fred" AND age:>18 AND NOT (gender:"male")'
+      expect(subject.build).to eq 'name:fred AND age:>18 AND NOT (gender:male)'
     end
   end
 


### PR DESCRIPTION
The contains? query method was doing the exact same thing as the eq method.
We tried to pass *'s to make it a query param from within our application, but due to the formatting of the String, this resulted in %22 being passed into the expression.

I've updated the contains? method to check that the value you pass works.
I've updated the values being used to always do `.to_s`, this was happening in the format method, but wrapping a string in quotes felt redundant and broken the `contains?` values we were passing.

## Testing
* In a pry within my application, I was able to use the changes in this PR with string fields and integer fields.
* I was able to use eq and contains? with words containing an apostrophe.