### PR TITLE
Allow for json query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v1.2.0
+* Added a json_query method to provide the ability to query ElasticSearch with a json object.
+
 ## v1.1.0
 
 * Fix the eq and contains? queries.

--- a/lib/elastic_search_framework/repository.rb
+++ b/lib/elastic_search_framework/repository.rb
@@ -83,8 +83,8 @@ module ElasticSearchFramework
       end
     end
 
-    def json_query(index:, json_query:, type: 'default', count: false)
-      uri = URI("#{host}/#{index.full_name}/#{type}/_search")
+    def json_query(index_name:, json_query:, type: 'default')
+      uri = URI("#{host}/#{index_name}/#{type}/_search")
 
       request = Net::HTTP::Get.new(uri.request_uri)
       request.body = json_query
@@ -95,12 +95,7 @@ module ElasticSearchFramework
 
       if is_valid_response?(response.code)
         result = JSON.parse(response.body)
-        hash_helper.indifferent!(result)
-        if count
-          return result[:hits][:total]
-        else
-          return result[:hits][:total] > 0 ? result[:hits][:hits] : []
-        end
+        return result['hits']
       else
         raise ElasticSearchFramework::Exceptions::IndexError.new("An error occurred executing an index query. Response: #{response.body}")
       end

--- a/lib/elastic_search_framework/repository.rb
+++ b/lib/elastic_search_framework/repository.rb
@@ -97,7 +97,6 @@ module ElasticSearchFramework
         result = JSON.parse(response.body)
         return result['hits']
       else
-        puts response.body
         raise(
           ElasticSearchFramework::Exceptions::IndexError,
           "An error occurred executing an index query. Response: #{response.body}"

--- a/lib/elastic_search_framework/repository.rb
+++ b/lib/elastic_search_framework/repository.rb
@@ -13,7 +13,7 @@ module ElasticSearchFramework
         client.request(request)
       end
 
-      unless is_valid_response?(response.code)
+      unless valid_response?(response.code)
         raise ElasticSearchFramework::Exceptions::IndexError.new(
             "An error occurred setting an index document. Response: #{response.body} | Code: #{response.code}"
         )
@@ -30,7 +30,7 @@ module ElasticSearchFramework
         client.request(request)
       end
 
-      if is_valid_response?(response.code)
+      if valid_response?(response.code)
         result = JSON.load(response.body)
         hash_helper.indifferent!(result)
         return result
@@ -52,7 +52,7 @@ module ElasticSearchFramework
         client.request(request)
       end
 
-      if is_valid_response?(response.code) || Integer(response.code) == 404
+      if valid_response?(response.code) || Integer(response.code) == 404
         return true
       else
         raise ElasticSearchFramework::Exceptions::IndexError.new(
@@ -70,7 +70,7 @@ module ElasticSearchFramework
         client.request(request)
       end
 
-      if is_valid_response?(response.code)
+      if valid_response?(response.code)
         result = JSON.parse(response.body)
         hash_helper.indifferent!(result)
         if count
@@ -93,11 +93,15 @@ module ElasticSearchFramework
         client.request(request)
       end
 
-      if is_valid_response?(response.code)
+      if valid_response?(response.code)
         result = JSON.parse(response.body)
         return result['hits']
       else
-        raise ElasticSearchFramework::Exceptions::IndexError.new("An error occurred executing an index query. Response: #{response.body}")
+        puts response.body
+        raise(
+          ElasticSearchFramework::Exceptions::IndexError,
+          "An error occurred executing an index query. Response: #{response.body}"
+        )
       end
     end
 
@@ -121,8 +125,8 @@ module ElasticSearchFramework
       @read_timeout ||= Integer(ENV['CONNECTION_OPEN_TIMEOUT'] ||  1)
     end
 
-    def is_valid_response?(status)
-      [200,201,202].include?(Integer(status))
+    def valid_response?(status)
+      [200, 201, 202].include?(Integer(status))
     end
 
     def host

--- a/lib/elastic_search_framework/version.rb
+++ b/lib/elastic_search_framework/version.rb
@@ -1,3 +1,3 @@
 module ElasticSearchFramework
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end


### PR DESCRIPTION
Added a json_query method to provide the ability to query ElasticSearch with a json object.