### PR TITLE
Allow use of mapping options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v1.4.0
+* Resolve JSON query to work with ES6 by adding the request content type.
+* Make the mapping method more flexible to allow more than just type and index to be passed for the mapping parameters/options.
+
+## v1.3.0
+* 1.3.0 was pushed and yanked from gem server.
+* Code did contain: Resolve JSON query to work with ES6 by adding the request content type.
+
 ## v1.2.0
 * Added a json_query method to provide the ability to query ElasticSearch with a json object.
 

--- a/lib/elastic_search_framework/index.rb
+++ b/lib/elastic_search_framework/index.rb
@@ -18,26 +18,21 @@ module ElasticSearchFramework
       end
     end
 
-    def mapping(name:, field:, type:, index:)
-
+    def mapping(name:, field:, **options)
       unless instance_variable_defined?(:@elastic_search_index_mappings)
         instance_variable_set(:@elastic_search_index_mappings, {})
       end
 
       mappings = instance_variable_get(:@elastic_search_index_mappings)
 
-      if mappings[name] == nil
-        mappings[name] = {}
-      end
+      mappings[name] = {} if mappings[name].nil?
 
-      mappings[name][field] = { type: type, index: index}
+      mappings[name][field] = options
 
       instance_variable_set(:@elastic_search_index_mappings, mappings)
-
     end
 
     def create
-
       if !valid?
         raise ElasticSearchFramework::Exceptions::IndexError.new("[#{self.class}] - Invalid Index description specified.")
       end
@@ -50,7 +45,6 @@ module ElasticSearchFramework
       payload = create_payload(description: description, mappings: mappings)
 
       put(payload: payload)
-
     end
 
     def put(payload:)
@@ -65,7 +59,7 @@ module ElasticSearchFramework
       end
 
       unless is_valid_response?(response.code)
-        if response.body.dig(:error, :root_cause, 0, :type) == 'index_already_exists_exception'
+        if JSON.parse(response.body).dig(:error, :root_cause, 0, :type) == 'index_already_exists_exception'
           # We get here because the `exists?` check in #create is non-atomic
           ElasticSearchFramework.logger.warn "[#{self.class}] - Failed to create preexisting index. | Response: #{response.body}"
         else
@@ -112,12 +106,11 @@ module ElasticSearchFramework
 
       if description[:shards] != nil
         payload[:settings] = {
-            number_of_shards: Integer(description[:shards])
+          number_of_shards: Integer(description[:shards])
         }
       end
 
       if mappings.keys.length > 0
-
         payload[:mappings] = {}
 
         mappings.keys.each do |name|
@@ -125,10 +118,7 @@ module ElasticSearchFramework
               properties: {}
           }
           mappings[name].keys.each do |field|
-            payload[:mappings][name][:properties][field] = {
-                type: mappings[name][field][:type],
-                index: mappings[name][field][:index]
-            }
+            payload[:mappings][name][:properties][field] = mappings[name][field]
           end
         end
 

--- a/lib/elastic_search_framework/index.rb
+++ b/lib/elastic_search_framework/index.rb
@@ -59,7 +59,7 @@ module ElasticSearchFramework
       end
 
       unless is_valid_response?(response.code)
-        if JSON.parse(response.body).dig(:error, :root_cause, 0, :type) == 'index_already_exists_exception'
+        if JSON.parse(response.body, symbolize_names: true).dig(:error, :root_cause, 0, :type) == 'index_already_exists_exception'
           # We get here because the `exists?` check in #create is non-atomic
           ElasticSearchFramework.logger.warn "[#{self.class}] - Failed to create preexisting index. | Response: #{response.body}"
         else

--- a/lib/elastic_search_framework/repository.rb
+++ b/lib/elastic_search_framework/repository.rb
@@ -87,6 +87,7 @@ module ElasticSearchFramework
       uri = URI("#{host}/#{index_name}/#{type}/_search")
 
       request = Net::HTTP::Get.new(uri.request_uri)
+      request.content_type = 'application/json'
       request.body = json_query
 
       response = with_client do |client|

--- a/lib/elastic_search_framework/version.rb
+++ b/lib/elastic_search_framework/version.rb
@@ -1,3 +1,3 @@
 module ElasticSearchFramework
-  VERSION = '1.2.0'
+  VERSION = '1.4.0'
 end

--- a/spec/elastic_search_framework/index_spec.rb
+++ b/spec/elastic_search_framework/index_spec.rb
@@ -9,6 +9,31 @@ RSpec.describe ElasticSearchFramework::Index do
     end
   end
 
+  describe '#index' do
+    before { ExampleIndex.create unless ExampleIndex.exists? }
+    context 'when the instance variable is not defined' do
+      before { allow(ExampleIndex).to receive(:instance_variable_defined?).and_return(true) }
+      it 'raises an index error' do
+        expect { ExampleIndex.index(name: 'test') }.to raise_error(
+          ElasticSearchFramework::Exceptions::IndexError,
+          "[Class] - Duplicate index description. Name: test | Shards: ."
+        )
+      end
+    end
+  end
+
+  describe '#id' do
+    context 'when the instance variable is not defined' do
+      before { allow(ExampleIndex).to receive(:instance_variable_defined?).and_return(true) }
+      it 'raises an index error' do
+        expect { ExampleIndex.id('name') }.to raise_error(
+          ElasticSearchFramework::Exceptions::IndexError,
+          "[Class] - Duplicate index id. Field: name."
+        )
+      end
+    end
+  end
+
   describe '#full_name' do
     let(:namespace) { 'uat' }
     let(:namespace_delimiter) { '.' }
@@ -18,6 +43,14 @@ RSpec.describe ElasticSearchFramework::Index do
     end
     it 'should return the full index name including namespace and delimiter' do
       expect(ExampleIndex.full_name).to eq "#{ElasticSearchFramework.namespace}#{ElasticSearchFramework.namespace_delimiter}#{ExampleIndex.description[:name]}"
+    end
+
+    context 'when the namespace is nil' do
+      before { ElasticSearchFramework.namespace = nil }
+
+      it 'returns the description name downcased' do
+        expect(ExampleIndex.full_name).to eq 'example_index'
+      end
     end
   end
 


### PR DESCRIPTION
Set the request.content_type for json query.
It is possible to add a few mapping parameters/options when creating an index.
This change makes the mapping method more flexible depending on the keys being used.
Increased version to 1.4.0 as 1.3.0 was pushed to gemserver by mistake.