### PR TITLE
Add the ability to provide analysis objects when creating your index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ index name: 'index_name', shards: 1
 This should now look as follows.
 ```
 index name 'index_name'
-settings name: :number_of_shards, payload: 1
+settings name: :number_of_shards, value: 1
 ```
 
 ## v1.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
-## v1.5.0
-* Add the ability to pass analysis options into the index. For example this allows you to define a normalizer or analyzer.
+## v2.0.0
+### Breaking change
+
+The index method no longer accepts shards as a parameter.
+This change follows the implementation of a new settings method allowing you to pass any number of settings objects to build out the index.
+
+Where the index method is currently being used as follows
+```
+index name: 'index_name', shards: 1
+```
+
+This should now look as follows.
+```
+index name 'index_name'
+settings name: :number_of_shards, payload: 1
+```
 
 ## v1.4.0
 * Resolve JSON query to work with ES6 by adding the request content type.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v1.5.0
+* Add the ability to pass analysis options into the index. For example this allows you to define a normalizer or analyzer.
+
 ## v1.4.0
 * Resolve JSON query to work with ES6 by adding the request content type.
 * Make the mapping method more flexible to allow more than just type and index to be passed for the mapping parameters/options.

--- a/lib/elastic_search_framework/index.rb
+++ b/lib/elastic_search_framework/index.rb
@@ -100,12 +100,12 @@ module ElasticSearchFramework
       is_valid_response?(response.code) || Integer(response.code) == 404
     end
 
-    def settings(name:, type: nil, payload:)
+    def settings(name:, type: nil, value:)
       self.index_settings = {} if index_settings.nil?
       index_settings[name] = if type
-                               { type => payload }
+                               { type => value }
                              else
-                               payload
+                               value
                              end
     end
 

--- a/lib/elastic_search_framework/index.rb
+++ b/lib/elastic_search_framework/index.rb
@@ -110,7 +110,7 @@ module ElasticSearchFramework
     end
 
     def create_payload
-      payload = { settings: {} }
+      payload = { }
       payload[:settings] = index_settings unless index_settings.nil?
 
       unless mappings.keys.empty?

--- a/lib/elastic_search_framework/index.rb
+++ b/lib/elastic_search_framework/index.rb
@@ -1,5 +1,7 @@
 module ElasticSearchFramework
   module Index
+    attr_accessor :index_analysis
+
     def index(name:, shards: nil)
       unless instance_variable_defined?(:@elastic_search_index_def)
         instance_variable_set(:@elastic_search_index_def, {
@@ -101,14 +103,16 @@ module ElasticSearchFramework
       is_valid_response?(response.code) || Integer(response.code) == 404
     end
 
+    def analysis(type:, payload:)
+      self.index_analysis = {} if index_analysis.nil?
+      index_analysis[type] = payload
+    end
+
     def create_payload(description:, mappings:)
       payload = {}
-
-      if description[:shards] != nil
-        payload[:settings] = {
-          number_of_shards: Integer(description[:shards])
-        }
-      end
+      payload[:settings] = {} if payload[:settings].nil?
+      payload[:settings][:number_of_shards] = Integer(description[:shards]) unless description[:shards].nil?
+      payload[:settings][:analysis] = index_analysis unless index_analysis.nil?
 
       if mappings.keys.length > 0
         payload[:mappings] = {}

--- a/lib/elastic_search_framework/version.rb
+++ b/lib/elastic_search_framework/version.rb
@@ -1,3 +1,3 @@
 module ElasticSearchFramework
-  VERSION = '1.4.0'
+  VERSION = '1.5.0'
 end

--- a/lib/elastic_search_framework/version.rb
+++ b/lib/elastic_search_framework/version.rb
@@ -1,3 +1,3 @@
 module ElasticSearchFramework
-  VERSION = '1.5.0'
+  VERSION = '2.0.0'
 end

--- a/spec/elastic_search_framework/index_spec.rb
+++ b/spec/elastic_search_framework/index_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe ElasticSearchFramework::Index do
       expect(ExampleIndex.description[:name]).to eq 'example_index'
       expect(ExampleIndex.description[:id]).to eq :id
       expect(ExampleIndexWithId.description[:id]).to eq :number
-      expect(ExampleIndexWithShard.description[:shards]).to eq 1
     end
   end
 
@@ -16,7 +15,7 @@ RSpec.describe ElasticSearchFramework::Index do
       it 'raises an index error' do
         expect { ExampleIndex.index(name: 'test') }.to raise_error(
           ElasticSearchFramework::Exceptions::IndexError,
-          "[Class] - Duplicate index description. Name: test | Shards: ."
+          '[Class] - Duplicate index description. Name: test.'
         )
       end
     end
@@ -70,12 +69,12 @@ RSpec.describe ElasticSearchFramework::Index do
 
       it 'does not add analysis to the index' do
         ExampleIndex.create
-        expect(ExampleIndexWithAnalysis.get.dig('example_index', 'settings', 'index', 'analysis')).to be_nil
+        expect(ExampleIndexWithSettings.get.dig('example_index', 'settings', 'index', 'analysis')).to be_nil
       end
     end
 
     context 'when analysis is not nil' do
-      before { ExampleIndexWithAnalysis.delete if ExampleIndexWithAnalysis.exists? }
+      before { ExampleIndexWithSettings.delete if ExampleIndexWithSettings.exists? }
       let(:expected) do
         {
           'normalizer' => {
@@ -88,8 +87,9 @@ RSpec.describe ElasticSearchFramework::Index do
       end
 
       it 'adds analysis to the index' do
-        ExampleIndexWithAnalysis.create
-        expect(ExampleIndexWithAnalysis.get.dig('example_index', 'settings', 'index', 'analysis')).to eq(expected)
+        ExampleIndexWithSettings.create
+        expect(ExampleIndexWithSettings.get.dig('example_index', 'settings', 'index', 'number_of_shards')).to eq('1')
+        expect(ExampleIndexWithSettings.get.dig('example_index', 'settings', 'index', 'analysis')).to eq(expected)
       end
     end
   end

--- a/spec/elastic_search_framework/index_spec.rb
+++ b/spec/elastic_search_framework/index_spec.rb
@@ -64,6 +64,36 @@ RSpec.describe ElasticSearchFramework::Index do
     end
   end
 
+  describe '#analysis' do
+    context 'when analysis is nil' do
+      before { ExampleIndex.delete if ExampleIndex.exists? }
+
+      it 'does not add analysis to the index' do
+        ExampleIndex.create
+        expect(ExampleIndexWithAnalysis.get.dig('example_index', 'settings', 'index', 'analysis')).to be_nil
+      end
+    end
+
+    context 'when analysis is not nil' do
+      before { ExampleIndexWithAnalysis.delete if ExampleIndexWithAnalysis.exists? }
+      let(:expected) do
+        {
+          'normalizer' => {
+            'custom_normalizer' => {
+              'filter' => ['lowercase'],
+              'type' => 'custom'
+            }
+          }
+        }
+      end
+
+      it 'adds analysis to the index' do
+        ExampleIndexWithAnalysis.create
+        expect(ExampleIndexWithAnalysis.get.dig('example_index', 'settings', 'index', 'analysis')).to eq(expected)
+      end
+    end
+  end
+
   describe '#valid?' do
     context 'for a valid index definition' do
       it 'should return true' do

--- a/spec/example_index.rb
+++ b/spec/example_index.rb
@@ -27,6 +27,14 @@ class ExampleIndexWithShard
 
 end
 
+class ExampleIndexWithAnalysis
+  extend ElasticSearchFramework::Index
+
+  index name: 'example_index', shards: 1
+  analysis type: :normalizer, payload: { custom_normalizer: { type: 'custom', char_filter: [], filter: ['lowercase'] } }
+  mapping name: 'default', field: :name, type: :keyword, index: true
+end
+
 class InvalidExampleIndex
   extend ElasticSearchFramework::Index
 end

--- a/spec/example_index.rb
+++ b/spec/example_index.rb
@@ -4,7 +4,6 @@ class ExampleIndex
   index name: 'example_index'
 
   mapping name: 'default', field: :name, type: :keyword, index: true
-
 end
 
 class ExampleIndexWithId
@@ -15,23 +14,17 @@ class ExampleIndexWithId
   id :number
 
   mapping name: 'default', field: :name, type: :keyword, index: true
-
 end
 
-class ExampleIndexWithShard
+class ExampleIndexWithSettings
   extend ElasticSearchFramework::Index
 
-  index name: 'example_index', shards: 1
+  index name: 'example_index'
 
-  mapping name: 'default', field: :name, type: :keyword, index: true
+  payload = { custom_normalizer: { type: 'custom', char_filter: [], filter: ['lowercase'] } }
 
-end
-
-class ExampleIndexWithAnalysis
-  extend ElasticSearchFramework::Index
-
-  index name: 'example_index', shards: 1
-  analysis type: :normalizer, payload: { custom_normalizer: { type: 'custom', char_filter: [], filter: ['lowercase'] } }
+  settings name: :number_of_shards, payload: 1
+  settings name: :analysis, type: :normalizer, payload: payload
   mapping name: 'default', field: :name, type: :keyword, index: true
 end
 

--- a/spec/example_index.rb
+++ b/spec/example_index.rb
@@ -21,10 +21,10 @@ class ExampleIndexWithSettings
 
   index name: 'example_index'
 
-  payload = { custom_normalizer: { type: 'custom', char_filter: [], filter: ['lowercase'] } }
+  normalizer_value = { custom_normalizer: { type: 'custom', char_filter: [], filter: ['lowercase'] } }
 
-  settings name: :number_of_shards, payload: 1
-  settings name: :analysis, type: :normalizer, payload: payload
+  settings name: :number_of_shards, value: 1
+  settings name: :analysis, type: :normalizer, value: normalizer_value
   mapping name: 'default', field: :name, type: :keyword, index: true
 end
 


### PR DESCRIPTION
**Introduces a breaking change**
The index method no longer accepts a parameter for shards.
This is now to be included within the new settings method.

The settings method allows you to provide any settings options when creating your index.