### PR TITLE
Fixes a bug with the settings method when passed multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v2.0.1
+The settings method when passed multiple times it was replacing the key value instead of building a hash of data within the name / type keys.
+
 ## v2.0.0
 ### Breaking change
 

--- a/lib/elastic_search_framework/index.rb
+++ b/lib/elastic_search_framework/index.rb
@@ -102,11 +102,9 @@ module ElasticSearchFramework
 
     def settings(name:, type: nil, value:)
       self.index_settings = {} if index_settings.nil?
-      index_settings[name] = if type
-                               { type => value }
-                             else
-                               value
-                             end
+      index_settings[name] = {} if index_settings[name].nil?
+      return index_settings[name][type] = value if type
+      index_settings[name] = value
     end
 
     def create_payload

--- a/lib/elastic_search_framework/version.rb
+++ b/lib/elastic_search_framework/version.rb
@@ -1,3 +1,3 @@
 module ElasticSearchFramework
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end

--- a/spec/elastic_search_framework/index_spec.rb
+++ b/spec/elastic_search_framework/index_spec.rb
@@ -82,7 +82,14 @@ RSpec.describe ElasticSearchFramework::Index do
               'filter' => ['lowercase'],
               'type' => 'custom'
             }
-          }
+          },
+          'analyzer'=>{
+              'custom_analyzer'=>{
+                'filter'=>['lowercase'],
+                'type'=>'custom',
+                'tokenizer'=>'standard'
+              }
+            }
         }
       end
 

--- a/spec/example_index.rb
+++ b/spec/example_index.rb
@@ -22,9 +22,11 @@ class ExampleIndexWithSettings
   index name: 'example_index'
 
   normalizer_value = { custom_normalizer: { type: 'custom', char_filter: [], filter: ['lowercase'] } }
+  analyzer_value = { custom_analyzer: { type: 'custom', tokenizer: 'standard', filter: %w(lowercase) } }
 
   settings name: :number_of_shards, value: 1
   settings name: :analysis, type: :normalizer, value: normalizer_value
+  settings name: :analysis, type: :analyzer, value: analyzer_value
   mapping name: 'default', field: :name, type: :keyword, index: true
 end
 


### PR DESCRIPTION
The settings method was not building a hash correctly and instead was overwriting the name and type values with the last one passed.