### PR TITLE
Fix read timeout setting on Net::HTTP client

### DIFF
--- a/lib/elastic_search_framework/repository.rb
+++ b/lib/elastic_search_framework/repository.rb
@@ -114,15 +114,15 @@ module ElasticSearchFramework
     end
 
     def idle_timeout
-      @idle_timeout ||= Integer(ENV['CONNECTION_IDLE_TIMEOUT'] ||  5)
+      @idle_timeout ||= Integer(ENV['CONNECTION_IDLE_TIMEOUT'] || 5)
     end
 
     def read_timeout
-      @read_timeout ||= Integer(ENV['CONNECTION_READ_TIMEOUT'] ||  5)
+      @read_timeout ||= Integer(ENV['CONNECTION_READ_TIMEOUT'] || 5)
     end
 
     def open_timeout
-      @read_timeout ||= Integer(ENV['CONNECTION_OPEN_TIMEOUT'] ||  1)
+      @open_timeout ||= Integer(ENV['CONNECTION_OPEN_TIMEOUT'] || 1)
     end
 
     def valid_response?(status)


### PR DESCRIPTION
Ensures that the read timeout is set to either the value of `ENV['CONNECTION_READ_TIMEOUT']` or `5` as a default.

Currently this is being set to the value of `ENV['CONNECTION_OPEN_TIMEOUT']` or `1` as a default.