### PR TITLE
Adds support for `op_type` to be supplied for `ElasticSearchFramework::Repository#set`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ rvm:
 - 2.3.0
 services:
 - elasticsearch
+before_install:
+- find /home/travis/.rvm/rubies -wholename '*default/bundler-*.gemspec' -delete
+- gem install bundler -v '< 2'
 before_script:
 - sleep 10
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v2.3.0
+Adds support for `op_type` to be supplied for `ElasticSearchFramework::Repository#set` to allow control of PUT behaviour in create scenarios.
+See [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docs-index_.html#operation-type) for more information and accepted values.
+
+## v2.2.0
+Adds index alias support.
+
 ## v2.1.0
 Ensures that the read timeout is set to either the value of `ENV['CONNECTION_READ_TIMEOUT']` or `5` as a default.
 Previously this was being set to the value of `ENV['CONNECTION_OPEN_TIMEOUT']` or `1` as a default.

--- a/lib/elastic_search_framework/version.rb
+++ b/lib/elastic_search_framework/version.rb
@@ -1,3 +1,3 @@
 module ElasticSearchFramework
-  VERSION = '2.2.0'
+  VERSION = '2.3.0'
 end


### PR DESCRIPTION
Adds support for `op_type` to be supplied for `ElasticSearchFramework::Repository#set` to allow control of PUT behavior in create scenarios.

See [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docs-index_.html#operation-type) for more information and accepted values.