### PR TITLE
Expose op_type to Index/IndexAlias classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v2.3.1
+Adds support for `op_type` to be supplied for `ElasticSearchFramework::Index#put_item` to allow control of PUT behaviour in create scenarios.
+Adds support for `op_type` to be supplied for `ElasticSearchFramework::IndexAlias#put_item` to allow control of PUT behaviour in create scenarios.
+See [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docs-index_.html#operation-type) for more information and accepted values.
+
 ## v2.3.0
 Adds support for `op_type` to be supplied for `ElasticSearchFramework::Repository#set` to allow control of PUT behaviour in create scenarios.
 See [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docs-index_.html#operation-type) for more information and accepted values.

--- a/lib/elastic_search_framework/index.rb
+++ b/lib/elastic_search_framework/index.rb
@@ -172,8 +172,8 @@ module ElasticSearchFramework
       repository.get(index: self, id: id, type: type)
     end
 
-    def put_item(type: 'default', item:)
-      repository.set(entity: item, index: self, type: type)
+    def put_item(type: 'default', item:, op_type: 'index')
+      repository.set(entity: item, index: self, type: type, op_type: op_type)
     end
 
     def delete_item(id:, type: 'default')

--- a/lib/elastic_search_framework/index_alias.rb
+++ b/lib/elastic_search_framework/index_alias.rb
@@ -127,9 +127,9 @@ module ElasticSearchFramework
       repository.get(index: self, id: id, type: type)
     end
 
-    def put_item(type: "default", item:)
+    def put_item(type: "default", item:, op_type: 'index')
       indexes.each do |index|
-        repository.set(entity: item, index: index[:klass], type: type)
+        repository.set(entity: item, index: index[:klass], type: type, op_type: op_type)
       end
     end
 

--- a/lib/elastic_search_framework/version.rb
+++ b/lib/elastic_search_framework/version.rb
@@ -1,3 +1,3 @@
 module ElasticSearchFramework
-  VERSION = '2.3.0'
+  VERSION = '2.3.1'
 end

--- a/spec/elastic_search_framework/index_alias_spec.rb
+++ b/spec/elastic_search_framework/index_alias_spec.rb
@@ -125,10 +125,26 @@ RSpec.describe ElasticSearchFramework::Index do
         i.number = 5
       end
     end
-    it 'should call set on the repository for each index of the alias' do
-      expect(ExampleIndexAlias.repository).to receive(:set).with(entity: item, index: ExampleIndex, type: type).once
-      expect(ExampleIndexAlias.repository).to receive(:set).with(entity: item, index: ExampleIndex2, type: type).once
-      ExampleIndexAlias.put_item(type: type, item: item)
+    context 'without specifying op_type' do
+      it 'should call set on the repository for each index of the alias with default op_type (index)' do
+        expect(ExampleIndexAlias.repository).to receive(:set).with(entity: item, index: ExampleIndex, type: type, op_type: 'index').once
+        expect(ExampleIndexAlias.repository).to receive(:set).with(entity: item, index: ExampleIndex2, type: type, op_type: 'index').once
+        ExampleIndexAlias.put_item(type: type, item: item)
+      end
+    end
+
+    context 'with specified op_type' do
+      it 'should call set on the repository for each index of the alias with supplied op_type (index)' do
+        expect(ExampleIndexAlias.repository).to receive(:set).with(entity: item, index: ExampleIndex, type: type, op_type: 'index').once
+        expect(ExampleIndexAlias.repository).to receive(:set).with(entity: item, index: ExampleIndex2, type: type, op_type: 'index').once
+        ExampleIndexAlias.put_item(type: type, item: item, op_type: 'index')
+      end
+
+      it 'should call set on the repository for each index of the alias with supplied op_type (create)' do
+        expect(ExampleIndexAlias.repository).to receive(:set).with(entity: item, index: ExampleIndex, type: type, op_type: 'create').once
+        expect(ExampleIndexAlias.repository).to receive(:set).with(entity: item, index: ExampleIndex2, type: type, op_type: 'create').once
+        ExampleIndexAlias.put_item(type: type, item: item, op_type: 'create')
+      end
     end
   end
 

--- a/spec/elastic_search_framework/index_spec.rb
+++ b/spec/elastic_search_framework/index_spec.rb
@@ -301,9 +301,24 @@ RSpec.describe ElasticSearchFramework::Index do
         i.number = 5
       end
     end
-    it 'should call set on the repository' do
-      expect_any_instance_of(ElasticSearchFramework::Repository).to receive(:set).with(entity: item, index: ExampleIndex, type: type)
-      ExampleIndex.put_item(type: type, item: item)
+
+    context 'without specifying op_type' do
+      it 'should call set on the repository with default op_type (index)' do
+        expect_any_instance_of(ElasticSearchFramework::Repository).to receive(:set).with(entity: item, index: ExampleIndex, op_type: 'index', type: type)
+        ExampleIndex.put_item(type: type, item: item)
+      end
+    end
+
+    context 'with specified op_type' do
+      it 'should call set on the repository with supplied op_type (index)' do
+        expect_any_instance_of(ElasticSearchFramework::Repository).to receive(:set).with(entity: item, index: ExampleIndex, op_type: 'index', type: type)
+        ExampleIndex.put_item(type: type, item: item, op_type: 'index')
+      end
+
+      it 'should call set on the repository with supplied op_type (create)' do
+        expect_any_instance_of(ElasticSearchFramework::Repository).to receive(:set).with(entity: item, index: ExampleIndex, op_type: 'create', type: type)
+        ExampleIndex.put_item(type: type, item: item, op_type: 'create')
+      end
     end
   end
 


### PR DESCRIPTION
See https://github.com/Sage/elastic_search_framework/pull/18

Exposes the `op_type` to Index/IndexAlias classes.