### PR TITLE
Add support for custom document routing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: Publish Gem
+on:
+  release:
+    types:
+      - "created"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Publish to RubyGems
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem build elastic_search_framework.gemspec
+          gem push elastic_search_framework.gem
+        env:
+          GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Runs Elasticsearch
         uses: elastic/elastic-github-actions/elasticsearch@master
         with:
-          stack-version: 5.6.16
+          stack-version: 7.6.0
 
       - name: Run tests
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: RSpec
+on:
+  - push
+  - pull_request
+  - repository_dispatch
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      elasticsearch:
+        image: elasticsearch
+        ports:
+          - 9200:9200
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.4
+          bundler-cache: true
+
+      - name: Run tests
+        env:
+          ELASTIC_SEARCH_HOST: http://localhost
+        run: bundle exec rspec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Runs Elasticsearch
         uses: elastic/elastic-github-actions/elasticsearch@master
         with:
-          stack-version: 7.6.0
+          stack-version: 6.8.17
 
       - name: Run tests
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,18 +8,24 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    services:
-      elasticsearch:
-        image: elasticsearch
-        ports:
-          - 9200:9200
-
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.4
           bundler-cache: true
+
+      - name: Configure sysctl limits
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+
+      - name: Runs Elasticsearch
+        uses: elastic/elastic-github-actions/elasticsearch@master
+        with:
+          stack-version: 5.6.0
 
       - name: Run tests
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: RSpec
 on:
   - push
-  - pull_request
-  - repository_dispatch
 
 jobs:
   test:
@@ -10,10 +8,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1.78.0
         with:
           ruby-version: 2.4
+          bundler: 1
           bundler-cache: true
+        env:
+          ImageOS: ubuntu18
 
       - name: Configure sysctl limits
         run: |
@@ -25,7 +26,7 @@ jobs:
       - name: Runs Elasticsearch
         uses: elastic/elastic-github-actions/elasticsearch@master
         with:
-          stack-version: 5.6.0
+          stack-version: 5.6.16
 
       - name: Run tests
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v2.4.0
+Adds support for `routing_key` to be supplied for `ElasticSearchFramework::IndexAlias#<get|put|delete>_item` to define a custom routing key when reading or writing index documents.
+
+Adds support for `routing_key` to be supplied for `ElasticSearchFramework::ShardedIndex#<get|put|delete>_item` to define a custom routing key when reading or writing index documents.
+
+**IMPORTANT** Default routing behaviour remains unless both a `routing_key` is supplied in the request, and the index class inherits from `ElasticSearchFramework::ShardedIndex`. `ElasticSearchFramework::Index` subclasses will not receive this update.
+
+See [documentation](https://www.elastic.co/blog/customizing-your-document-routing) for more information.
+
 ## v2.3.1
 Adds support for `op_type` to be supplied for `ElasticSearchFramework::Index#put_item` to allow control of PUT behaviour in create scenarios.
 Adds support for `op_type` to be supplied for `ElasticSearchFramework::IndexAlias#put_item` to allow control of PUT behaviour in create scenarios.

--- a/lib/elastic_search_framework.rb
+++ b/lib/elastic_search_framework.rb
@@ -9,6 +9,7 @@ require_relative 'elastic_search_framework/exceptions'
 require_relative 'elastic_search_framework/repository'
 require_relative 'elastic_search_framework/index'
 require_relative 'elastic_search_framework/index_alias'
+require_relative 'elastic_search_framework/sharded_index'
 require_relative 'elastic_search_framework/query'
 
 module ElasticSearchFramework

--- a/lib/elastic_search_framework/index.rb
+++ b/lib/elastic_search_framework/index.rb
@@ -2,11 +2,10 @@ module ElasticSearchFramework
   module Index
     attr_accessor :index_settings
 
-    def index(name:, version: nil, routing: false)
+    def index(name:, version: nil)
       unless instance_variable_defined?(:@elastic_search_index_def)
         instance_variable_set(:@elastic_search_index_def, name: "#{name}#{version}")
         instance_variable_set(:@elastic_search_index_version, version: version) unless version.nil?
-        # instance_variable_set(:@elastic_search_index_routing, routing)
       else
         raise ElasticSearchFramework::Exceptions::IndexError.new("[#{self.class}] - Duplicate index description. Name: #{name}.")
       end
@@ -15,10 +14,6 @@ module ElasticSearchFramework
     def version
       instance_variable_defined?(:@elastic_search_index_version) ? instance_variable_get(:@elastic_search_index_version) : 0
     end
-
-    # def enable_routing
-    #   @@routing = true
-    # end
 
     def routing_enabled?
       false

--- a/lib/elastic_search_framework/repository.rb
+++ b/lib/elastic_search_framework/repository.rb
@@ -1,8 +1,11 @@
 module ElasticSearchFramework
   class Repository
 
-    def set(index:, entity:, type: 'default', op_type: 'index')
-      uri = URI("#{host}/#{index.full_name}/#{type.downcase}/#{get_id_value(index: index, entity: entity)}?op_type=#{op_type}")
+    def set(index:, entity:, type: 'default', op_type: 'index', routing_key: nil)
+      uri_string = "#{host}/#{index.full_name}/#{type.downcase}/#{get_id_value(index: index, entity: entity)}?op_type=#{op_type}"
+      uri_string += "&routing=#{routing_key}" if routing_key
+
+      uri = URI(uri_string)
       hash = hash_helper.to_hash(entity)
 
       request = Net::HTTP::Put.new(uri.request_uri)
@@ -24,8 +27,11 @@ module ElasticSearchFramework
       end
     end
 
-    def get(index:, id:, type: 'default')
-      uri = URI("#{host}/#{index.full_name}/#{type.downcase}/#{id}/_source")
+    def get(index:, id:, type: 'default', routing_key: nil)
+      uri_string = "#{host}/#{index.full_name}/#{type.downcase}/#{id}/_source"
+      uri_string += "?routing=#{routing_key}" if routing_key
+
+      uri = URI(uri_string)
 
       request = Net::HTTP::Get.new(uri.request_uri)
 
@@ -46,8 +52,11 @@ module ElasticSearchFramework
       end
     end
 
-    def drop(index:, id:, type: 'default')
-      uri = URI("#{host}/#{index.full_name}/#{type.downcase}/#{id}")
+    def drop(index:, id:, type: 'default', routing_key: nil)
+      uri_string = "#{host}/#{index.full_name}/#{type.downcase}/#{id}"
+      uri_string += "?routing=#{routing_key}" if routing_key
+
+      uri = URI(uri_string)
 
       request = Net::HTTP::Delete.new(uri.request_uri)
 
@@ -64,8 +73,11 @@ module ElasticSearchFramework
       end
     end
 
-    def query(index:, expression:, type: 'default', limit: 10, count: false)
-      uri = URI("#{host}/#{index.full_name}/#{type}/_search?q=#{URI.encode(expression)}&size=#{limit}")
+    def query(index:, expression:, type: 'default', limit: 10, count: false, routing_key: nil)
+      uri_string = "#{host}/#{index.full_name}/#{type}/_search?q=#{URI.encode(expression)}&size=#{limit}"
+      uri_string += "&routing=#{routing_key}" if routing_key
+
+      uri = URI(uri_string)
 
       request = Net::HTTP::Get.new(uri.request_uri)
 
@@ -86,8 +98,11 @@ module ElasticSearchFramework
       end
     end
 
-    def json_query(index_name:, json_query:, type: 'default')
-      uri = URI("#{host}/#{index_name}/#{type}/_search")
+    def json_query(index_name:, json_query:, type: 'default', routing_key: nil)
+      uri_string = "#{host}/#{index_name}/#{type}/_search"
+      uri_string += "?routing=#{routing_key}" if routing_key
+
+      uri = URI(uri_string)
 
       request = Net::HTTP::Get.new(uri.request_uri)
       request.content_type = 'application/json'

--- a/lib/elastic_search_framework/sharded_index.rb
+++ b/lib/elastic_search_framework/sharded_index.rb
@@ -2,11 +2,10 @@ module ElasticSearchFramework
   module ShardedIndex
     attr_accessor :index_settings
 
-    def index(name:, version: nil, routing: false)
+    def index(name:, version: nil)
       unless instance_variable_defined?(:@elastic_search_index_def)
         instance_variable_set(:@elastic_search_index_def, name: "#{name}#{version}")
         instance_variable_set(:@elastic_search_index_version, version: version) unless version.nil?
-        # instance_variable_set(:@elastic_search_index_routing, routing)
       else
         raise ElasticSearchFramework::Exceptions::IndexError.new("[#{self.class}] - Duplicate index description. Name: #{name}.")
       end
@@ -15,10 +14,6 @@ module ElasticSearchFramework
     def version
       instance_variable_defined?(:@elastic_search_index_version) ? instance_variable_get(:@elastic_search_index_version) : 0
     end
-
-    # def enable_routing
-    #   @@routing = true
-    # end
 
     def routing_enabled?
       true

--- a/lib/elastic_search_framework/sharded_index.rb
+++ b/lib/elastic_search_framework/sharded_index.rb
@@ -1,5 +1,5 @@
 module ElasticSearchFramework
-  module Index
+  module ShardedIndex
     attr_accessor :index_settings
 
     def index(name:, version: nil, routing: false)
@@ -21,7 +21,7 @@ module ElasticSearchFramework
     # end
 
     def routing_enabled?
-      false
+      true
     end
 
     def id(field)

--- a/lib/elastic_search_framework/version.rb
+++ b/lib/elastic_search_framework/version.rb
@@ -1,3 +1,3 @@
 module ElasticSearchFramework
-  VERSION = '2.3.1'
+  VERSION = '2.4.0'
 end

--- a/spec/elastic_search_framework/index_alias_spec.rb
+++ b/spec/elastic_search_framework/index_alias_spec.rb
@@ -108,9 +108,23 @@ RSpec.describe ElasticSearchFramework::Index do
   describe '#get_item' do
     let(:id) { 10 }
     let(:type) { 'default' }
-    it 'should call get on the repository' do
-      expect(ExampleIndexAlias.repository).to receive(:get).with(index: ExampleIndexAlias, id: id, type: type).once
-      ExampleIndexAlias.get_item(id: id, type: type)
+    context 'when active index routing_enabled false' do
+      it 'should call get on the repository' do
+        expect(ExampleIndexAlias.repository).to receive(:get).with(index: ExampleIndexAlias, id: id, type: type).once
+        ExampleIndexAlias.get_item(id: id, type: type)
+      end
+
+      it 'should call get on the repository and not pass through routing_key when supplied' do
+        expect(ExampleIndexAlias.repository).to receive(:get).with(index: ExampleIndexAlias, id: id, type: type).once
+        ExampleIndexAlias.get_item(id: id, type: type, routing_key: 5)
+      end
+    end
+
+    context 'when active index routing_enabled true' do
+      it 'should call get on the repository' do
+        expect(ExampleIndexAlias2.repository).to receive(:get).with(index: ExampleIndexAlias2, id: id, type: type, routing_key: 5).once
+        ExampleIndexAlias2.get_item(id: id, type: type, routing_key: 5)
+      end
     end
   end
 
@@ -128,22 +142,22 @@ RSpec.describe ElasticSearchFramework::Index do
     context 'without specifying op_type' do
       it 'should call set on the repository for each index of the alias with default op_type (index)' do
         expect(ExampleIndexAlias.repository).to receive(:set).with(entity: item, index: ExampleIndex, type: type, op_type: 'index').once
-        expect(ExampleIndexAlias.repository).to receive(:set).with(entity: item, index: ExampleIndex2, type: type, op_type: 'index').once
-        ExampleIndexAlias.put_item(type: type, item: item)
+        expect(ExampleIndexAlias.repository).to receive(:set).with(entity: item, index: ExampleIndex2, type: type, op_type: 'index', routing_key: 5).once
+        ExampleIndexAlias.put_item(type: type, item: item, routing_key: 5)
       end
     end
 
     context 'with specified op_type' do
       it 'should call set on the repository for each index of the alias with supplied op_type (index)' do
         expect(ExampleIndexAlias.repository).to receive(:set).with(entity: item, index: ExampleIndex, type: type, op_type: 'index').once
-        expect(ExampleIndexAlias.repository).to receive(:set).with(entity: item, index: ExampleIndex2, type: type, op_type: 'index').once
-        ExampleIndexAlias.put_item(type: type, item: item, op_type: 'index')
+        expect(ExampleIndexAlias.repository).to receive(:set).with(entity: item, index: ExampleIndex2, type: type, op_type: 'index', routing_key: 5).once
+        ExampleIndexAlias.put_item(type: type, item: item, op_type: 'index', routing_key: 5)
       end
 
       it 'should call set on the repository for each index of the alias with supplied op_type (create)' do
         expect(ExampleIndexAlias.repository).to receive(:set).with(entity: item, index: ExampleIndex, type: type, op_type: 'create').once
-        expect(ExampleIndexAlias.repository).to receive(:set).with(entity: item, index: ExampleIndex2, type: type, op_type: 'create').once
-        ExampleIndexAlias.put_item(type: type, item: item, op_type: 'create')
+        expect(ExampleIndexAlias.repository).to receive(:set).with(entity: item, index: ExampleIndex2, type: type, op_type: 'create', routing_key: 5).once
+        ExampleIndexAlias.put_item(type: type, item: item, op_type: 'create', routing_key: 5)
       end
     end
   end
@@ -153,8 +167,8 @@ RSpec.describe ElasticSearchFramework::Index do
     let(:type) { 'default' }
     it 'should call drop on the repository for each index of the alias' do
       expect(ExampleIndexAlias.repository).to receive(:drop).with(index: ExampleIndex, id: id, type: type).once
-      expect(ExampleIndexAlias.repository).to receive(:drop).with(index: ExampleIndex2, id: id, type: type).once
-      ExampleIndexAlias.delete_item(id: id, type: type)
+      expect(ExampleIndexAlias.repository).to receive(:drop).with(index: ExampleIndex2, id: id, type: type, routing_key: 5).once
+      ExampleIndexAlias.delete_item(id: id, type: type, routing_key: 5)
     end
   end
 end

--- a/spec/elastic_search_framework/index_spec.rb
+++ b/spec/elastic_search_framework/index_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe ElasticSearchFramework::Index do
         {
           'normalizer' => {
             'custom_normalizer' => {
+              'char_filter' => [],
               'filter' => ['lowercase'],
               'type' => 'custom'
             }

--- a/spec/elastic_search_framework/sharded_index_spec.rb
+++ b/spec/elastic_search_framework/sharded_index_spec.rb
@@ -1,19 +1,19 @@
-RSpec.describe ElasticSearchFramework::Index do
+RSpec.describe ElasticSearchFramework::ShardedIndex do
   describe '#description' do
     it 'should return the index details' do
-      expect(ExampleIndex.description).to be_a(Hash)
-      expect(ExampleIndex.description[:name]).to eq 'example_index'
-      expect(ExampleIndex.description[:id]).to eq :id
-      expect(ExampleIndexWithId.description[:id]).to eq :number
+      expect(ExampleIndex2.description).to be_a(Hash)
+      expect(ExampleIndex2.description[:name]).to eq 'example_index2'
+      expect(ExampleIndex2.description[:id]).to eq :id
+      expect(ExampleIndexWithId2.description[:id]).to eq :number
     end
   end
 
   describe '#index' do
-    before { ExampleIndex.create unless ExampleIndex.exists? }
+    before { ExampleIndex2.create unless ExampleIndex2.exists? }
     context 'when the instance variable is not defined' do
-      before { allow(ExampleIndex).to receive(:instance_variable_defined?).and_return(true) }
+      before { allow(ExampleIndex2).to receive(:instance_variable_defined?).and_return(true) }
       it 'raises an index error' do
-        expect { ExampleIndex.index(name: 'test') }.to raise_error(
+        expect { ExampleIndex2.index(name: 'test') }.to raise_error(
           ElasticSearchFramework::Exceptions::IndexError,
           '[Class] - Duplicate index description. Name: test.'
         )
@@ -23,9 +23,9 @@ RSpec.describe ElasticSearchFramework::Index do
 
   describe '#id' do
     context 'when the instance variable is not defined' do
-      before { allow(ExampleIndex).to receive(:instance_variable_defined?).and_return(true) }
+      before { allow(ExampleIndex2).to receive(:instance_variable_defined?).and_return(true) }
       it 'raises an index error' do
-        expect { ExampleIndex.id('name') }.to raise_error(
+        expect { ExampleIndex2.id('name') }.to raise_error(
           ElasticSearchFramework::Exceptions::IndexError,
           "[Class] - Duplicate index id. Field: name."
         )
@@ -41,21 +41,21 @@ RSpec.describe ElasticSearchFramework::Index do
       ElasticSearchFramework.namespace_delimiter = namespace_delimiter
     end
     it 'should return the full index name including namespace and delimiter' do
-      expect(ExampleIndex.full_name).to eq "#{ElasticSearchFramework.namespace}#{ElasticSearchFramework.namespace_delimiter}#{ExampleIndex.description[:name]}"
+      expect(ExampleIndex2.full_name).to eq "#{ElasticSearchFramework.namespace}#{ElasticSearchFramework.namespace_delimiter}#{ExampleIndex2.description[:name]}"
     end
 
     context 'when the namespace is nil' do
       before { ElasticSearchFramework.namespace = nil }
 
       it 'returns the description name downcased' do
-        expect(ExampleIndex.full_name).to eq 'example_index'
+        expect(ExampleIndex2.full_name).to eq 'example_index2'
       end
     end
   end
 
   describe '#mapping' do
     it 'should add mapping details to the index definition' do
-      mappings = ExampleIndex.mappings
+      mappings = ExampleIndex2.mappings
       expect(mappings).to be_a(Hash)
       expect(mappings.length).to eq 1
       expect(mappings['default'][:name][:type]).to eq :keyword
@@ -65,16 +65,16 @@ RSpec.describe ElasticSearchFramework::Index do
 
   describe '#analysis' do
     context 'when analysis is nil' do
-      before { ExampleIndex.delete if ExampleIndex.exists? }
+      before { ExampleIndex2.delete if ExampleIndex2.exists? }
 
       it 'does not add analysis to the index' do
-        ExampleIndex.create
-        expect(ExampleIndexWithSettings.get.dig('example_index', 'settings', 'index', 'analysis')).to be_nil
+        ExampleIndex2.create
+        expect(ExampleIndexWithSettings2.get.dig('example_index2', 'settings', 'index', 'analysis')).to be_nil
       end
     end
 
     context 'when analysis is not nil' do
-      before { ExampleIndexWithSettings.delete if ExampleIndexWithSettings.exists? }
+      before { ExampleIndexWithSettings2.delete if ExampleIndexWithSettings2.exists? }
       let(:expected) do
         {
           'normalizer' => {
@@ -94,9 +94,9 @@ RSpec.describe ElasticSearchFramework::Index do
       end
 
       it 'adds analysis to the index' do
-        ExampleIndexWithSettings.create
-        expect(ExampleIndexWithSettings.get.dig('example_index', 'settings', 'index', 'number_of_shards')).to eq('1')
-        expect(ExampleIndexWithSettings.get.dig('example_index', 'settings', 'index', 'analysis')).to eq(expected)
+        ExampleIndexWithSettings2.create
+        expect(ExampleIndexWithSettings2.get.dig('example_index2', 'settings', 'index', 'number_of_shards')).to eq('1')
+        expect(ExampleIndexWithSettings2.get.dig('example_index2', 'settings', 'index', 'analysis')).to eq(expected)
       end
     end
   end
@@ -104,37 +104,37 @@ RSpec.describe ElasticSearchFramework::Index do
   describe '#valid?' do
     context 'for a valid index definition' do
       it 'should return true' do
-        expect(ExampleIndex.valid?).to be true
+        expect(ExampleIndex2.valid?).to be true
       end
     end
     context 'for an invalid index definition' do
       it 'should return true' do
-        expect(InvalidExampleIndex.valid?).to be false
+        expect(InvalidExampleIndex2.valid?).to be false
       end
     end
   end
 
   describe '#create' do
     context 'when index is valid and does not exist' do
-      before { ExampleIndex.delete if ExampleIndex.exists? }
+      before { ExampleIndex2.delete if ExampleIndex2.exists? }
 
       it 'should create an index' do
-        expect(ExampleIndex.exists?).to be false
-        ExampleIndex.create
-        expect(ExampleIndex.exists?).to be true
+        expect(ExampleIndex2.exists?).to be false
+        ExampleIndex2.create
+        expect(ExampleIndex2.exists?).to be true
       end
 
       after do
-        ExampleIndex.delete
+        ExampleIndex2.delete
       end
     end
 
     context 'when index is not valid' do
-      before { allow(ExampleIndex).to receive(:valid?).and_return(false) }
+      before { allow(ExampleIndex2).to receive(:valid?).and_return(false) }
 
       it 'raises an error' do
-        expect(ExampleIndex.exists?).to be false
-        expect { ExampleIndex.create }.to raise_error(
+        expect(ExampleIndex2.exists?).to be false
+        expect { ExampleIndex2.create }.to raise_error(
           ElasticSearchFramework::Exceptions::IndexError,
           '[Class] - Invalid Index description specified.'
         )
@@ -142,45 +142,45 @@ RSpec.describe ElasticSearchFramework::Index do
     end
 
     context 'when index is valid but already exists' do
-      before { ExampleIndex.delete if ExampleIndex.exists? }
+      before { ExampleIndex2.delete if ExampleIndex2.exists? }
 
       it 'does not try to create a new index' do
-        allow(ExampleIndex).to receive(:exists?).and_return(true)
-        expect(ExampleIndex).not_to receive(:put)
-        ExampleIndex.create
+        allow(ExampleIndex2).to receive(:exists?).and_return(true)
+        expect(ExampleIndex2).not_to receive(:put)
+        ExampleIndex2.create
       end
     end
   end
 
   describe '#delete' do
     before do
-      unless ExampleIndex.exists?
-        ExampleIndex.create
+      unless ExampleIndex2.exists?
+        ExampleIndex2.create
       end
     end
     it 'should create an index' do
-      expect(ExampleIndex.exists?).to be true
-      ExampleIndex.delete
-      expect(ExampleIndex.exists?).to be false
+      expect(ExampleIndex2.exists?).to be true
+      ExampleIndex2.delete
+      expect(ExampleIndex2.exists?).to be false
     end
   end
 
   describe '#exists?' do
     context 'when an index exists' do
       before do
-        ExampleIndex.delete
-        ExampleIndex.create
+        ExampleIndex2.delete
+        ExampleIndex2.create
       end
       it 'should return true' do
-        expect(ExampleIndex.exists?).to be true
+        expect(ExampleIndex2.exists?).to be true
       end
     end
     context 'when an index exists' do
       before do
-        ExampleIndex.delete
+        ExampleIndex2.delete
       end
       it 'should return false' do
-        expect(ExampleIndex.exists?).to be false
+        expect(ExampleIndex2.exists?).to be false
       end
     end
   end
@@ -188,27 +188,27 @@ RSpec.describe ElasticSearchFramework::Index do
   describe '#put' do
     let(:payload) { {} }
     context 'when there is a valid response' do
-      before { allow(ExampleIndex).to receive(:is_valid_response?).and_return(true) }
+      before { allow(ExampleIndex2).to receive(:is_valid_response?).and_return(true) }
 
       it 'returns true' do
-        ExampleIndex.create
-        expect(ExampleIndex.put(payload: payload)).to eq true
+        ExampleIndex2.create
+        expect(ExampleIndex2.put(payload: payload)).to eq true
       end
     end
 
     context 'when there is not a valid response' do
-      before { allow(ExampleIndex).to receive(:is_valid_response?).and_return(false) }
+      before { allow(ExampleIndex2).to receive(:is_valid_response?).and_return(false) }
 
       context 'when the error is "index_already_exists_exception"' do
         let(:response_body) { { error: { root_cause: [{ type: 'index_already_exists_exception' }] } } }
         let(:request) { double }
 
-        before { ExampleIndex.delete if ExampleIndex.exists? }
+        before { ExampleIndex2.delete if ExampleIndex2.exists? }
         it 'returns true' do
           allow(request).to receive(:body).and_return(response_body.to_json)
           allow(request).to receive(:code).and_return(404)
           allow_any_instance_of(Net::HTTP).to receive(:request).and_return(request)
-          expect(ExampleIndex.put(payload: payload)).to eq true
+          expect(ExampleIndex2.put(payload: payload)).to eq true
         end
       end
 
@@ -219,7 +219,7 @@ RSpec.describe ElasticSearchFramework::Index do
           allow(request).to receive(:body).and_return(response_body.to_json)
           allow(request).to receive(:code).and_return(404)
           allow_any_instance_of(Net::HTTP).to receive(:request).and_return(request)
-          expect { ExampleIndex.put(payload: payload) }.to raise_error(
+          expect { ExampleIndex2.put(payload: payload) }.to raise_error(
             ElasticSearchFramework::Exceptions::IndexError
           )
         end
@@ -231,53 +231,53 @@ RSpec.describe ElasticSearchFramework::Index do
     let(:code) { 200 }
     context 'when a 200 response code is returned' do
       it 'should return true' do
-        expect(ExampleIndex.is_valid_response?(code)).to be true
+        expect(ExampleIndex2.is_valid_response?(code)).to be true
       end
     end
     context 'when a 201 response code is returned' do
       let(:code) { 201 }
       it 'should return true' do
-        expect(ExampleIndex.is_valid_response?(code)).to be true
+        expect(ExampleIndex2.is_valid_response?(code)).to be true
       end
     end
     context 'when a 202 response code is returned' do
       let(:code) { 202 }
       it 'should return true' do
-        expect(ExampleIndex.is_valid_response?(code)).to be true
+        expect(ExampleIndex2.is_valid_response?(code)).to be true
       end
     end
     context 'when a 400 response code is returned' do
       let(:code) { 400 }
       it 'should return false' do
-        expect(ExampleIndex.is_valid_response?(code)).to be false
+        expect(ExampleIndex2.is_valid_response?(code)).to be false
       end
     end
     context 'when a 401 response code is returned' do
       let(:code) { 401 }
       it 'should return false' do
-        expect(ExampleIndex.is_valid_response?(code)).to be false
+        expect(ExampleIndex2.is_valid_response?(code)).to be false
       end
     end
     context 'when a 500 response code is returned' do
       let(:code) { 500 }
       it 'should return false' do
-        expect(ExampleIndex.is_valid_response?(code)).to be false
+        expect(ExampleIndex2.is_valid_response?(code)).to be false
       end
     end
   end
 
   describe '#host' do
     it 'should return the expected host based on default host & port values' do
-      expect(ExampleIndex.host).to eq "#{ElasticSearchFramework.host}:#{ElasticSearchFramework.port}"
+      expect(ExampleIndex2.host).to eq "#{ElasticSearchFramework.host}:#{ElasticSearchFramework.port}"
     end
   end
 
   describe '#repository' do
     it 'should return a ElasticSearchFramework::Repository instance' do
-      expect(ExampleIndex.repository).to be_a(ElasticSearchFramework::Repository)
+      expect(ExampleIndex2.repository).to be_a(ElasticSearchFramework::Repository)
     end
     it 'should return the same ElasticSearchFramework::Repository instance for multiple calls' do
-      expect(ExampleIndex.repository).to eq ExampleIndex.repository
+      expect(ExampleIndex2.repository).to eq ExampleIndex2.repository
     end
   end
 
@@ -285,8 +285,8 @@ RSpec.describe ElasticSearchFramework::Index do
     let(:id) { 10 }
     let(:type) { 'default' }
     it 'should call get on the repository' do
-      expect_any_instance_of(ElasticSearchFramework::Repository).to receive(:get).with(index: ExampleIndex, id: id, type: type)
-      ExampleIndex.get_item(id: id, type: type)
+      expect_any_instance_of(ElasticSearchFramework::Repository).to receive(:get).with(index: ExampleIndex2, id: id, type: type)
+      ExampleIndex2.get_item(id: id, type: type)
     end
   end
 
@@ -304,34 +304,34 @@ RSpec.describe ElasticSearchFramework::Index do
 
     context 'without specifying op_type' do
       it 'should call set on the repository with default op_type (index)' do
-        expect_any_instance_of(ElasticSearchFramework::Repository).to receive(:set).with(entity: item, index: ExampleIndex, op_type: 'index', type: type)
-        ExampleIndex.put_item(type: type, item: item)
+        expect_any_instance_of(ElasticSearchFramework::Repository).to receive(:set).with(entity: item, index: ExampleIndex2, op_type: 'index', type: type)
+        ExampleIndex2.put_item(type: type, item: item)
       end
     end
 
     context 'with specified op_type' do
       it 'should call set on the repository with supplied op_type (index)' do
-        expect_any_instance_of(ElasticSearchFramework::Repository).to receive(:set).with(entity: item, index: ExampleIndex, op_type: 'index', type: type)
-        ExampleIndex.put_item(type: type, item: item, op_type: 'index')
+        expect_any_instance_of(ElasticSearchFramework::Repository).to receive(:set).with(entity: item, index: ExampleIndex2, op_type: 'index', type: type)
+        ExampleIndex2.put_item(type: type, item: item, op_type: 'index')
       end
 
       it 'should call set on the repository with supplied op_type (create)' do
-        expect_any_instance_of(ElasticSearchFramework::Repository).to receive(:set).with(entity: item, index: ExampleIndex, op_type: 'create', type: type)
-        ExampleIndex.put_item(type: type, item: item, op_type: 'create')
+        expect_any_instance_of(ElasticSearchFramework::Repository).to receive(:set).with(entity: item, index: ExampleIndex2, op_type: 'create', type: type)
+        ExampleIndex2.put_item(type: type, item: item, op_type: 'create')
       end
     end
 
     context 'without specifying routing_key' do
       it 'should call set on the repository without routing_key' do
-        expect_any_instance_of(ElasticSearchFramework::Repository).to receive(:set).with(entity: item, index: ExampleIndex, op_type: 'index', type: type)
-        ExampleIndex.put_item(type: type, item: item, op_type: 'index')
+        expect_any_instance_of(ElasticSearchFramework::Repository).to receive(:set).with(entity: item, index: ExampleIndex2, op_type: 'index', type: type)
+        ExampleIndex2.put_item(type: type, item: item, op_type: 'index')
       end
     end
 
     context 'with specified routing_key' do
-      it 'should call set on the repository without routing_key' do
-        expect_any_instance_of(ElasticSearchFramework::Repository).to receive(:set).with(entity: item, index: ExampleIndex, op_type: 'index', type: type)
-        ExampleIndex.put_item(type: type, item: item, op_type: 'index', routing_key: '6')
+      it 'should call set on the repository with routing_key' do
+        expect_any_instance_of(ElasticSearchFramework::Repository).to receive(:set).with(entity: item, index: ExampleIndex2, op_type: 'index', type: type, routing_key: 6)
+        ExampleIndex2.put_item(type: type, item: item, op_type: 'index', routing_key: 6)
       end
     end
   end
@@ -340,8 +340,8 @@ RSpec.describe ElasticSearchFramework::Index do
     let(:id) { 10 }
     let(:type) { 'default' }
     it 'should call drop on the repository' do
-      expect_any_instance_of(ElasticSearchFramework::Repository).to receive(:drop).with(index: ExampleIndex, id: id, type: type)
-      ExampleIndex.delete_item(id: id, type: type)
+      expect_any_instance_of(ElasticSearchFramework::Repository).to receive(:drop).with(index: ExampleIndex2, id: id, type: type)
+      ExampleIndex2.delete_item(id: id, type: type)
     end
   end
 end

--- a/spec/elastic_search_framework/sharded_index_spec.rb
+++ b/spec/elastic_search_framework/sharded_index_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe ElasticSearchFramework::ShardedIndex do
         {
           'normalizer' => {
             'custom_normalizer' => {
+              'char_filter' => [],
               'filter' => ['lowercase'],
               'type' => 'custom'
             }

--- a/spec/example_index_2.rb
+++ b/spec/example_index_2.rb
@@ -1,5 +1,5 @@
 class ExampleIndex2
-  extend ElasticSearchFramework::Index
+  extend ElasticSearchFramework::ShardedIndex
 
   index name: 'example_index', version: 2
 
@@ -7,7 +7,7 @@ class ExampleIndex2
 end
 
 class ExampleIndexWithId2
-  extend ElasticSearchFramework::Index
+  extend ElasticSearchFramework::ShardedIndex
 
   index name: 'example_index', version: 2
 
@@ -17,7 +17,7 @@ class ExampleIndexWithId2
 end
 
 class ExampleIndexWithSettings2
-  extend ElasticSearchFramework::Index
+  extend ElasticSearchFramework::ShardedIndex
 
   index name: 'example_index', version: 2
 
@@ -28,4 +28,8 @@ class ExampleIndexWithSettings2
   settings name: :analysis, type: :normalizer, value: normalizer_value
   settings name: :analysis, type: :analyzer, value: analyzer_value
   mapping name: 'default', field: :name, type: :keyword, index: true
+end
+
+class InvalidExampleIndex2
+  extend ElasticSearchFramework::ShardedIndex
 end


### PR DESCRIPTION
Adds support for `routing_key` to be supplied for `ElasticSearchFramework::IndexAlias#<get|put|delete>_item` to define a custom routing key when reading or writing index documents.

Adds support for `routing_key` to be supplied for `ElasticSearchFramework::ShardedIndex#<get|put|delete>_item` to define a custom routing key when reading or writing index documents.

**IMPORTANT** Default routing behaviour remains unless both a `routing_key` is supplied in the request, and the index class inherits from `ElasticSearchFramework::ShardedIndex`. `ElasticSearchFramework::Index` subclasses will not receive this update.

See [documentation](https://www.elastic.co/blog/customizing-your-document-routing) for more information.